### PR TITLE
Add libraries multiboot2:start and psys:start

### DIFF
--- a/app/sandbox/build.gradle.kts
+++ b/app/sandbox/build.gradle.kts
@@ -13,7 +13,7 @@ application {
     )
 
     dependencies {
-        implementation(project(":psys:multiboot2"))
+        implementation(project(":psys:start"))
         implementation(project(":x86"))
     }
 

--- a/app/sandbox/src/main/cpp/main.cpp
+++ b/app/sandbox/src/main/cpp/main.cpp
@@ -1,16 +1,14 @@
 // Copyright (C) 2021,2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 #include <psys/integer.h>
-
-#include <multiboot2/header.h>
-#include <multiboot2/information.h>
+#include <psys/start.h>
 
 #include <x86/port.h>
 
 
-namespace app
+namespace psys
 {
-    void main ( multiboot2::information_list & response )
+    void main ()
     {
         // Look for this output in QEMU debugcon!
 

--- a/gradle/plugins/src/main/kotlin/psys-test.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/psys-test.gradle.kts
@@ -21,7 +21,6 @@ project.afterEvaluate {
                 description = "creates image"
                 inputFile.set(executable)
             }
-            project.tasks.assemble { dependsOn(create) }
             val image = create.flatMap { it.outputFile }
             project.tasks.register<MultibootRunImageTask>("run-image-${name}") {
                 group = "psys"

--- a/multiboot2/start/build.gradle.kts
+++ b/multiboot2/start/build.gradle.kts
@@ -18,8 +18,7 @@ library {
     )
 
     dependencies {
-        api(project(":psys"))
-        api(project("::multiboot2"))
+        api(project(":multiboot2"))
     }
 
     binaries.configureEach {

--- a/multiboot2/start/src/main/cpp/start.cpp
+++ b/multiboot2/start/src/main/cpp/start.cpp
@@ -1,27 +1,13 @@
 // Copyright (C) 2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 
-#include <psys/size.h>
-#include <psys/test.h>
-
 #include <multiboot2/header.h>
-#include <multiboot2/information.h>
+#include <multiboot2/start.h>
 
 
-//! Application.
-
-namespace app
+namespace multiboot2
 {
-    void main ( multiboot2::information_list & response );
-}
-
-//! Multiboot2 loader protocol.
-
-namespace
-{
-    using namespace multiboot2;
-
-    //! Multiboot2 request.
+    //! Request.
 
     struct request_type
     {
@@ -37,18 +23,13 @@ namespace
         { },
     };
 
-    //! Multiboot2 start procedure.
+    //! Start procedure stack.
 
     [[gnu::section(".multiboot2.stack")]]
     constinit
     unsigned char stack [ 0x4000 ] {};
 
-    [[gnu::section(".multiboot2.start")]]
-    void main ( ps::size4 magic, multiboot2::information_list & response )
-    {
-        if (magic != information_magic) return;
-        app::main(response);
-    }
+    //! Start procedure.
 
     extern "C"
     [[gnu::naked, gnu::section(".multiboot2.start"), gnu::used]]
@@ -65,14 +46,10 @@ namespace
             xor ecx, ecx
             push ecx
             popf
-            // mark test start
-            call _test_start
             // call C++
             push ebx
             push eax
             call main
-            // mark test finish
-            call _test_finish
             // finish
             cli
           halt:

--- a/multiboot2/start/src/main/cpp/start.cpp
+++ b/multiboot2/start/src/main/cpp/start.cpp
@@ -65,14 +65,10 @@ namespace multiboot2
             xor ecx, ecx
             push rcx
             popf
-            // mark test start
-            call _test_start
             // call C++
             push rbx
             push rax
             call main
-            // mark test finish
-            call _test_finish
             // finish
           finish:
             cli

--- a/multiboot2/start/src/main/public/multiboot2/start.h
+++ b/multiboot2/start/src/main/public/multiboot2/start.h
@@ -1,0 +1,9 @@
+// Copyright (C) 2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+
+
+#include <multiboot2/information.h>
+
+namespace multiboot2
+{
+    void main ( ps::size4 magic, multiboot2::information_list & response );
+}

--- a/multiboot2/test/x86_32-elf/entry/src/main/cpp/main.cpp
+++ b/multiboot2/test/x86_32-elf/entry/src/main/cpp/main.cpp
@@ -12,9 +12,10 @@
 namespace
 {
     [[gnu::used]]
-    void test ()
+    void test ( ps::size magic )
     {
         _test_control = 1;
+        if (magic != multiboot2::information_magic) _test_control = 0;
         _test_control = -1;
     }
 }
@@ -47,22 +48,15 @@ namespace multiboot2
     [[gnu::naked, gnu::section(".multiboot2.start"), gnu::used]]
     void multiboot2_custom ()
     {
+#if defined(__i386__)
         __asm__
         {
-#if defined(__i386__)
             mov esp, offset stack + 0x4000
             xor ecx, ecx
             push ecx
             popf
-#elif defined(__x86_64__)
-            mov rsp, offset stack + 0x4000
-            xor rcx, rcx
-            push rcx
-            popf
-#else
-# error unsupported target
-#endif
             call _test_start
+            push eax
             call test
             call _test_finish
             cli
@@ -70,6 +64,25 @@ namespace multiboot2
             hlt
             jmp loop
         }
+#elif defined(__x86_64__)
+        __asm__
+        {
+            mov rsp, offset stack + 0x4000
+            xor rcx, rcx
+            push rcx
+            popf
+            call _test_start
+            push rax
+            call test
+            call _test_finish
+            cli
+        loop:
+            hlt
+            jmp loop
+        }
+#else
+# error unsupported target
+#endif
     }
 
     // Incorrect entry point.

--- a/multiboot2/test/x86_32-elf/layout/src/main/cpp/main.cpp
+++ b/multiboot2/test/x86_32-elf/layout/src/main/cpp/main.cpp
@@ -12,9 +12,10 @@
 namespace
 {
     [[gnu::used]]
-    void test ()
+    void test ( ps::size magic )
     {
         _test_control = 1;
+        if (magic != multiboot2::information_magic) _test_control = 0;
         _test_control = -1;
     }
 
@@ -75,22 +76,15 @@ namespace multiboot2
     [[gnu::naked, gnu::section(".multiboot2.start")]]
     void multiboot2_start ()
     {
+#if defined(__i386__)
         __asm__
         {
-#if defined(__i386__)
             mov esp, offset stack + 0x4000
             xor ecx, ecx
             push ecx
             popf
-#elif defined(__x86_64__)
-            mov rsp, offset stack + 0x4000
-            xor rcx, rcx
-            push rcx
-            popf
-#else
-# error unsupported target
-#endif
             call _test_start
+            push eax
             call test
             call _test_finish
             cli
@@ -98,6 +92,25 @@ namespace multiboot2
             hlt
             jmp loop
         }
+#elif defined(__x86_64__)
+        __asm__
+        {
+            mov rsp, offset stack + 0x4000
+            xor rcx, rcx
+            push rcx
+            popf
+            call _test_start
+            push rax
+            call test
+            call _test_finish
+            cli
+        loop:
+            hlt
+            jmp loop
+        }
+#else
+# error unsupported target
+#endif
     }
 
     // Incorrect entry point.

--- a/pc/test/x86_32-elf-multiboot2/build.gradle.kts
+++ b/pc/test/x86_32-elf-multiboot2/build.gradle.kts
@@ -18,7 +18,7 @@ subprojects {
 
         dependencies {
             implementation(project(":pc"))
-            implementation(project(":psys:multiboot2"))
+            implementation(project(":psys:start"))
             implementation(project(":x86"))
         }
 

--- a/pc/test/x86_32-elf-multiboot2/cmos/src/main/cpp/main.cpp
+++ b/pc/test/x86_32-elf-multiboot2/cmos/src/main/cpp/main.cpp
@@ -2,21 +2,15 @@
 
 
 #include <psys/integer.h>
+#include <psys/start.h>
 #include <psys/test.h>
-
-#include <multiboot2/information.h>
 
 #include <x86/port.h>
 
 #include <pc/cmos.h>
 
 
-namespace app
-{
-    void main ( multiboot2::information_list & mbi );
-}
-
-void app::main ( multiboot2::information_list & mbi )
+void psys::main ()
 {
     pc::cmos<x86::port> cmos { 0x70, 0x71 };
     

--- a/pc/test/x86_32-elf-multiboot2/cmos/src/main/cpp/main.cpp
+++ b/pc/test/x86_32-elf-multiboot2/cmos/src/main/cpp/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+// Copyright (C) 2020,2021,2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 
 #include <psys/integer.h>

--- a/pc/test/x86_32-elf-multiboot2/pic/src/main/cpp/main.cpp
+++ b/pc/test/x86_32-elf-multiboot2/pic/src/main/cpp/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+// Copyright (C) 2020,2021,2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 
 #include <psys/integer.h>

--- a/pc/test/x86_32-elf-multiboot2/pic/src/main/cpp/main.cpp
+++ b/pc/test/x86_32-elf-multiboot2/pic/src/main/cpp/main.cpp
@@ -2,9 +2,8 @@
 
 
 #include <psys/integer.h>
+#include <psys/start.h>
 #include <psys/test.h>
-
-#include <multiboot2/information.h>
 
 #include <x86/cpuid.h>
 #include <x86/gdt.h>
@@ -15,7 +14,7 @@
 #include <pc/pic.h>
 
 
-namespace app
+namespace
 {
     void set_global_descriptor_table_register ();
 
@@ -25,11 +24,9 @@ namespace app
     unsigned interrupt_counter {};
 
     void set_interrupt_descriptor_table_register ();
-
-    void main ( multiboot2::information_list & mbi );
 }
 
-void app::main ( multiboot2::information_list & mbi )
+void psys::main ()
 {
     using namespace x86;
 
@@ -109,7 +106,7 @@ void app::main ( multiboot2::information_list & mbi )
     return;
 }
 
-namespace app
+namespace
 {
     using namespace x86;
     using namespace x86::_32;

--- a/pc/test/x86_32-elf-multiboot2/pit/src/main/cpp/main.cpp
+++ b/pc/test/x86_32-elf-multiboot2/pit/src/main/cpp/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+// Copyright (C) 2021,2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 
 #include <psys/integer.h>

--- a/pc/test/x86_32-elf-multiboot2/pit/src/main/cpp/main.cpp
+++ b/pc/test/x86_32-elf-multiboot2/pit/src/main/cpp/main.cpp
@@ -2,9 +2,8 @@
 
 
 #include <psys/integer.h>
+#include <psys/start.h>
 #include <psys/test.h>
-
-#include <multiboot2/information.h>
 
 #include <x86/cpuid.h>
 #include <x86/gdt.h>
@@ -16,7 +15,7 @@
 #include <pc/pit.h>
 
 
-namespace app
+namespace
 {
     void set_global_descriptor_table_register ();
 
@@ -26,11 +25,9 @@ namespace app
     unsigned interrupt_counter {};
 
     void set_interrupt_descriptor_table_register ();
-
-    void main ( multiboot2::information_list & mbi );
 }
 
-void app::main ( multiboot2::information_list & mbi )
+void psys::main ()
 {
     using namespace x86;
 
@@ -207,7 +204,7 @@ void app::main ( multiboot2::information_list & mbi )
     return;
 }
 
-namespace app
+namespace
 {
     using namespace x86;
     using namespace x86::_32;

--- a/pc/test/x86_32-elf-multiboot2/uart/src/main/cpp/main.cpp
+++ b/pc/test/x86_32-elf-multiboot2/uart/src/main/cpp/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+// Copyright (C) 2021,2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 
 #include <psys/integer.h>

--- a/pc/test/x86_32-elf-multiboot2/uart/src/main/cpp/main.cpp
+++ b/pc/test/x86_32-elf-multiboot2/uart/src/main/cpp/main.cpp
@@ -2,9 +2,8 @@
 
 
 #include <psys/integer.h>
+#include <psys/start.h>
 #include <psys/test.h>
-
-#include <multiboot2/information.h>
 
 #include <x86/gdt.h>
 #include <x86/idt.h>
@@ -14,7 +13,7 @@
 #include <pc/uart.h>
 
 
-namespace app
+namespace
 {
     void set_global_descriptor_table_register ();
 
@@ -24,11 +23,9 @@ namespace app
     unsigned interrupt_counter {};
 
     void set_interrupt_descriptor_table_register ();
-
-    void main ( multiboot2::information_list & mbi );
 }
 
-void app::main ( multiboot2::information_list & mbi )
+void psys::main ()
 {
     using namespace pc::uart;
     using namespace x86;
@@ -164,9 +161,7 @@ void app::main ( multiboot2::information_list & mbi )
     return;
 }
 
-//! Application implementation.
-
-namespace app
+namespace
 {
     using namespace x86;
     using namespace x86::_32;

--- a/psys/start/build.gradle.kts
+++ b/psys/start/build.gradle.kts
@@ -1,0 +1,28 @@
+import dev.nokee.platform.nativebase.NativeBinary
+
+plugins {
+    id("psys-component")
+}
+
+library {
+    targetLinkages.add(linkages.static)
+
+    targetMachines.addAll(
+        // #XXX: build on any for x86_32-elf-multiboot2
+        machines.os("host").architecture("-x86_32-elf-multiboot2"),
+        // #XXX: build on any for x86_64-elf-multiboot2
+        machines.os("host").architecture("-x86_64-elf-multiboot2"),
+    )
+
+    dependencies {
+        implementation(project(":multiboot2:start"))
+    }
+
+    binaries.configureEach {
+        if (this is NativeBinary) {
+            compileTasks.configureEach {
+                compilerArgs.addAll("-std=c++20", "-flto", "-fasm-blocks")
+            }
+        }
+    }
+}

--- a/psys/start/src/main/cpp/start.cpp
+++ b/psys/start/src/main/cpp/start.cpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+
+
+#include <psys/size.h>
+#include <psys/start.h>
+#include <psys/test.h>
+
+#include <multiboot2/start.h>
+
+
+namespace multiboot2
+{
+    void main ( ps::size4 magic, multiboot2::information_list & response )
+    {
+        if (magic != information_magic) return;
+        _test_start();
+        psys::main();
+        _test_finish();
+    }
+}

--- a/psys/start/src/main/public/psys/start.h
+++ b/psys/start/src/main/public/psys/start.h
@@ -1,0 +1,7 @@
+// Copyright (C) 2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+
+
+namespace psys
+{
+    void main ();
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include("acpi")
 include("googletest")
 
 include("multiboot2")
+include("multiboot2:start")
 rootProject.projectDir.resolve("multiboot2/test/x86_32-elf").toPath().apply {
     Files.list(this).forEach {
         if (Files.isDirectory(it))
@@ -52,7 +53,7 @@ rootProject.projectDir.resolve("pc/test/x86_32-elf-multiboot2").toPath().apply {
 }
 
 include("psys")
-include("psys:multiboot2")
+include("psys:start")
 
 include("x86")
 rootProject.projectDir.resolve("x86/test/x86_32-elf-multiboot2").toPath().apply {

--- a/x86/test/x86_32-elf-multiboot2/build.gradle.kts
+++ b/x86/test/x86_32-elf-multiboot2/build.gradle.kts
@@ -17,7 +17,7 @@ subprojects {
         )
 
         dependencies {
-            implementation(project(":psys:multiboot2"))
+            implementation(project(":psys:start"))
             implementation(project(":x86"))
         }
 

--- a/x86/test/x86_32-elf-multiboot2/cpuid/src/main/cpp/main.cpp
+++ b/x86/test/x86_32-elf-multiboot2/cpuid/src/main/cpp/main.cpp
@@ -1,19 +1,13 @@
 // Copyright (C) 2020, 2021 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 #include <psys/integer.h>
+#include <psys/start.h>
 #include <psys/test.h>
-
-#include <multiboot2/information.h>
 
 #include <x86/cpuid.h>
 
 
-namespace app
-{
-    void main ( multiboot2::information_list & mbi );
-}
-
-void app::main ( multiboot2::information_list & mbi )
+void psys::main ()
 {
     _test_control = 1;
 

--- a/x86/test/x86_32-elf-multiboot2/cpuid/src/main/cpp/main.cpp
+++ b/x86/test/x86_32-elf-multiboot2/cpuid/src/main/cpp/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+// Copyright (C) 2020,2021,2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 #include <psys/integer.h>
 #include <psys/start.h>

--- a/x86/test/x86_32-elf-multiboot2/exception/src/main/cpp/main.cpp
+++ b/x86/test/x86_32-elf-multiboot2/exception/src/main/cpp/main.cpp
@@ -2,15 +2,14 @@
 
 
 #include <psys/integer.h>
+#include <psys/start.h>
 #include <psys/test.h>
-
-#include <multiboot2/information.h>
 
 #include <x86/gdt.h>
 #include <x86/idt.h>
 
 
-namespace app
+namespace
 {
     using namespace x86;
     using namespace x86::_32;
@@ -55,11 +54,9 @@ namespace app
 
     unsigned interrupt_FF_counter {};
     void interrupt_FF ();
-
-    void main ( multiboot2::information_list & mbi );
 }
 
-void app::main ( multiboot2::information_list & mbi )
+void psys::main ()
 {
     using namespace ps;
     using namespace x86;
@@ -160,7 +157,7 @@ void app::main ( multiboot2::information_list & mbi )
     return;
 }
 
-namespace app
+namespace
 {
     using namespace x86;
     using namespace x86::_32;

--- a/x86/test/x86_32-elf-multiboot2/exception/src/main/cpp/main.cpp
+++ b/x86/test/x86_32-elf-multiboot2/exception/src/main/cpp/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+// Copyright (C) 2020,2021,2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 
 #include <psys/integer.h>

--- a/x86/test/x86_32-elf-multiboot2/gdt/src/main/cpp/main.cpp
+++ b/x86/test/x86_32-elf-multiboot2/gdt/src/main/cpp/main.cpp
@@ -2,14 +2,13 @@
 
 
 #include <psys/integer.h>
+#include <psys/start.h>
 #include <psys/test.h>
-
-#include <multiboot2/information.h>
 
 #include <x86/gdt.h>
 
 
-namespace app
+namespace
 {
     using namespace x86;
     using namespace x86::_32;
@@ -33,11 +32,9 @@ namespace app
         // user flat data descriptor
         { 0, 0xFFFFF, data_segment(true, true, true), 3, true, true, true, true, },
     };
-
-    void main ( multiboot2::information_list & mbi );
 }
 
-void app::main ( multiboot2::information_list & mbi )
+void psys::main ()
 {
     using namespace x86;
     using namespace x86::_32;

--- a/x86/test/x86_32-elf-multiboot2/gdt/src/main/cpp/main.cpp
+++ b/x86/test/x86_32-elf-multiboot2/gdt/src/main/cpp/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+// Copyright (C) 2020,2021,2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 
 #include <psys/integer.h>

--- a/x86/test/x86_32-elf-multiboot2/idt/src/main/cpp/main.cpp
+++ b/x86/test/x86_32-elf-multiboot2/idt/src/main/cpp/main.cpp
@@ -2,15 +2,14 @@
 
 
 #include <psys/integer.h>
+#include <psys/start.h>
 #include <psys/test.h>
-
-#include <multiboot2/information.h>
 
 #include <x86/gdt.h>
 #include <x86/idt.h>
 
 
-namespace app
+namespace
 {
     using namespace x86;
     using namespace x86::_32;;
@@ -60,11 +59,9 @@ namespace app
             iretd
         }
     }
-
-    void main ( multiboot2::information_list & mbi );
 }
 
-void app::main ( multiboot2::information_list & mbi )
+void psys::main ()
 {
     using namespace ps;
     using namespace x86;

--- a/x86/test/x86_32-elf-multiboot2/idt/src/main/cpp/main.cpp
+++ b/x86/test/x86_32-elf-multiboot2/idt/src/main/cpp/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
+// Copyright (C) 2020,2021,2022 Pedro Lamarão <pedro.lamarao@gmail.com>. All rights reserved.
 
 
 #include <psys/integer.h>

--- a/x86/test/x86_32-elf-multiboot2/main/src/main/cpp/main.cpp
+++ b/x86/test/x86_32-elf-multiboot2/main/src/main/cpp/main.cpp
@@ -2,26 +2,13 @@
 
 
 #include <psys/integer.h>
-
-#include <multiboot2/information.h>
-
+#include <psys/start.h>
 #include <psys/test.h>
 
 
-namespace app
-{
-    void main ( multiboot2::information_list & response );
-}
-
-void app::main ( multiboot2::information_list & response )
+void psys::main ()
 {
     _test_control = 1;
-
-    if ((& response) == nullptr) {
-        _test_control = 0;
-        return;
-    }
-
     _test_control = -1;
     return;
 }

--- a/x86/test/x86_32-elf-multiboot2/msr/src/main/cpp/main.cpp
+++ b/x86/test/x86_32-elf-multiboot2/msr/src/main/cpp/main.cpp
@@ -2,9 +2,8 @@
 
 
 #include <psys/integer.h>
+#include <psys/start.h>
 #include <psys/test.h>
-
-#include <multiboot2/information.h>
 
 #include <x86/cpuid.h>
 #include <x86/gdt.h>
@@ -12,12 +11,7 @@
 #include <x86/msr.h>
 
 
-namespace app
-{
-    void main ( multiboot2::information_list & mbi );
-}
-
-void app::main ( multiboot2::information_list & mbi )
+void psys::main ()
 {
     using namespace x86;
 


### PR DESCRIPTION
Add two separate start libraries defining entry point protocols.

`multiboot2:start` receives control from a Multiboot2 loader and calls `multiboo2::main` with the magic number and the information object.

`psys:start` receives control from start libraries (such as `multiboot2:start`) and sets up testing.